### PR TITLE
Change collaborator API URL to 'citizencollab' subdomain

### DIFF
--- a/inventory/prod.yml
+++ b/inventory/prod.yml
@@ -52,7 +52,7 @@ all:
         aws_storage_bucket_name: muni-portal-backend
         aws_s3_custom_domain: muni-portal-backend.s3.amazonaws.com
         media_url: https://muni-portal-backend.s3.amazonaws.com/
-        collaborator_api_base_url: https://consumercollab.collaboratoronline.com
+        collaborator_api_base_url: https://citizencollab.collaboratoronline.com
 
     procurement-portal-backend:
       hosts:

--- a/inventory/sandbox.yml
+++ b/inventory/sandbox.yml
@@ -39,4 +39,4 @@ all:
         aws_storage_bucket_name: muni-portal-backend-sandbox
         aws_s3_custom_domain: muni-portal-backend-sandbox.s3.amazonaws.com
         media_url: https://muni-portal-backend-sandbox.s3.amazonaws.com/
-        collaborator_api_base_url: https://consumercollab.collaboratoronline.com
+        collaborator_api_base_url: https://citizencollab.collaboratoronline.com

--- a/inventory/staging.yml
+++ b/inventory/staging.yml
@@ -39,4 +39,4 @@ all:
         aws_storage_bucket_name: muni-portal-backend-staging
         aws_s3_custom_domain: muni-portal-backend-staging.s3.amazonaws.com
         media_url: https://muni-portal-backend-staging.s3.amazonaws.com/
-        collaborator_api_base_url: https://consumercollab.collaboratoronline.com
+        collaborator_api_base_url: https://citizencollab.collaboratoronline.com


### PR DESCRIPTION
Changes the collaborator API url from `consumercollab.` to `citizencollab.`