### PR TITLE
Drop to single worker to avoid race conditions

### DIFF
--- a/apps/wazimap-ng/playbook.yml
+++ b/apps/wazimap-ng/playbook.yml
@@ -75,6 +75,7 @@
           ENVIRONMENT_NAME: "{{ env_name }}"
           PORT: "8000"
           Q_CLUSTER_RECYCLE: "1"
+          Q_CLUSTER_WORKERS: "1"
           SENTRY_DSN: "https://aae3ed779891437d984db424db5c9dd0@o242378.ingest.sentry.io/5257787"
           STAFF_EMAIL_ADDRESS: "support@wazimap.co.za"
       tags:


### PR DESCRIPTION
Multiple workers were racing working on the same datasets. Until we can serialise work on an item, let's reduce to one worker.

The race seemed to result in deadlock with full CPU consumption.